### PR TITLE
Add support to perform an action when a modal is closed

### DIFF
--- a/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
+++ b/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
@@ -25,7 +25,12 @@ export default function ChallengeSubmissionGroup(props: Props) {
         const answerObj = new Answer(Number(props.challenge.id), answer);
         try {
             if (await answerObj.verify()) {
-                openModal("Congratulations!", ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type], "success");
+                openModal(
+                    "Congratulations!",
+                    ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type],
+                    "success",
+                    () => (window.location.href = "/"),
+                );
                 return true;
             } else {
                 openModal("Oopsie! ☹️", ANSWER_VERIFICATION_MESSAGES.FAILURE[props.challenge.type], "error");

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -7,7 +7,7 @@ import SuccessModal from "@/components/modals/SuccessModal";
 type ModalType = "success" | "error" | "info" | "warning";
 
 type ModalContextType = {
-    openModal: (title: string, message: string, modalType: ModalType) => void;
+    openModal: (title: string, message: string, modalType: ModalType, onCloseAction?: () => void) => void;
     closeModal: () => void;
 };
 
@@ -25,10 +25,16 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
     const [modalContent, setModalContent] = useState<{ title: string; message: string } | null>(null);
     const [modalType, setModalType] = useState<ModalType>("info");
     const [modalOpened, setModalOpened] = useState<boolean>(false);
+    const [onCloseAction, setOnCloseAction] = useState<() => () => void>(() => () => {});
 
-    const openModal = (title: string, message: string, type: ModalType) => {
+    const openModal = (title: string, message: string, type: ModalType, closeAction?: () => void) => {
         setModalContent({ title, message });
         setModalType(type);
+
+        if (closeAction) {
+            setOnCloseAction(() => closeAction);
+        }
+
         setModalOpened(true);
     };
 
@@ -36,6 +42,9 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
         setModalOpened(false);
         setModalContent(null);
         setModalType("info");
+
+        onCloseAction();
+        setOnCloseAction(() => () => {});
     };
 
     return (

--- a/src/hooks/CreateChallengeFormHook.ts
+++ b/src/hooks/CreateChallengeFormHook.ts
@@ -39,7 +39,12 @@ export default function useCreateChallengeForm() {
         try {
             const values = form.getValues();
             await ChallengeFactory.create(values);
-            openModal("Success! 😄", "Challenge created successfully!", "success");
+            openModal(
+                "Success! 😄",
+                "Challenge created successfully!",
+                "success",
+                () => (window.location.href = "/admin/challenges"),
+            );
         } catch (error) {
             if (error instanceof Error) openModal("Oh no! ☹️", error.message, "error");
             else openModal("Oh no! ☹️", "There was an error creating the challenge. Please try again later.", "error");


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/17

This pull request introduces a new feature that allows specifying an optional callback function to be executed when a modal is closed. The most important changes include modifications to the `openModal` function signature, updates to the modal state management, and applying the new feature in specific components.

Enhancements to modal functionality:

* [`src/components/modals/Modal.tsx`](diffhunk://#diff-aaed6e4d0411b6c1148fbe75ae6442f082f22ba8c9c603e63fe704a47935447eL10-R10): Updated the `openModal` function to accept an optional `onCloseAction` callback parameter and modified the state management to handle this new parameter. [[1]](diffhunk://#diff-aaed6e4d0411b6c1148fbe75ae6442f082f22ba8c9c603e63fe704a47935447eL10-R10) [[2]](diffhunk://#diff-aaed6e4d0411b6c1148fbe75ae6442f082f22ba8c9c603e63fe704a47935447eR28-R47)

Application of the new modal feature:

* [`src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx`](diffhunk://#diff-91aaee1e3cbdfa14f86085759e9814e9311fab74fbe9d040566ae09b4c53a633L28-R33): Added a callback to redirect the user to the homepage upon successful challenge submission.
* [`src/hooks/CreateChallengeFormHook.ts`](diffhunk://#diff-477d439413a475122f04a743ab261a45b47fb4be01a8dc14ccadbc0adccb4f83L42-R47): Added a callback to redirect the user to the admin challenges page upon successful challenge creation.