### PR TITLE
Add loading state check to answer badges in SubmitPhotoSubmission

### DIFF
--- a/src/components/forms/submit-photo/SubmitPhotoSubmission.tsx
+++ b/src/components/forms/submit-photo/SubmitPhotoSubmission.tsx
@@ -35,8 +35,9 @@ export default function SubmitPhotoSubmission(props: Props) {
                 label={"Your submission"}
                 disableRemove={answerCorrect}
             />
-            {answerChanged && !answerCorrect && <IncorrectAnswerBadge />}
-            {answerChanged && answerCorrect && <CorrectAnswerBadge />}
+
+            {answerChanged && !loading && !answerCorrect && <IncorrectAnswerBadge />}
+            {answerChanged && !loading && answerCorrect && <CorrectAnswerBadge />}
 
             {!answerCorrect && answer && (
                 <SubmitButton


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/15

This pull request includes a small change to the `SubmitPhotoSubmission` component in `src/components/forms/submit-photo/SubmitPhotoSubmission.tsx`. The change ensures that the `IncorrectAnswerBadge` and `CorrectAnswerBadge` components are only displayed when the `loading` state is false.

* [`src/components/forms/submit-photo/SubmitPhotoSubmission.tsx`](diffhunk://#diff-d24c5d439833ae63da6ceeaec1ad7cfb4f55482ddd23640a7f4e9c921d602be6L38-R40): Added a check for the `loading` state before rendering `IncorrectAnswerBadge` and `CorrectAnswerBadge`.