### PR TITLE
Clean up code associated with modals usage

### DIFF
--- a/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
+++ b/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
@@ -7,51 +7,32 @@ import SubmitAnswerSubmission from "@/components/forms/submit-answer/SubmitAnswe
 import SubmitPhotoSubmission, {
     SubmitPhotoSubmissionSkeleton,
 } from "@/components/forms/submit-photo/SubmitPhotoSubmission";
+import { getErrorModal } from "@/constants/modal-templates";
 
 type Props = {
     challenge: Challenge;
 };
 
-// TODO: simplify this component logic
 export default function ChallengeSubmissionGroup(props: Props) {
     const { openModal } = useModal();
 
     async function submitAnswer(answer: string | null): Promise<boolean> {
         if (!answer) {
-            openModal({
-                title: "Oopsie! ☹️",
-                message: ANSWER_VERIFICATION_MESSAGES.NO_ANSWER[props.challenge.type],
-                type: "error",
-            });
+            openModal(getErrorModal(ANSWER_VERIFICATION_MESSAGES.NO_ANSWER[props.challenge.type]));
             return false;
         }
 
-        const answerObj = new Answer(Number(props.challenge.id), answer);
+        const answerObj = new Answer(props.challenge.id, answer);
         try {
             if (await answerObj.verify()) {
-                openModal({
-                    title: "Woo hoo!",
-                    message: ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type],
-                    type: "success",
-                    closeAction: () => (window.location.href = "/"),
-                });
+                openModal(getErrorModal(ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type]));
                 return true;
             } else {
-                openModal({
-                    title: "Oopsie! ☹️",
-                    message: ANSWER_VERIFICATION_MESSAGES.FAILURE[props.challenge.type],
-                    type: "error",
-                    additionalDetails: "fuck off nerd",
-                });
+                openModal(getErrorModal(ANSWER_VERIFICATION_MESSAGES.FAILURE[props.challenge.type]));
                 return false;
             }
         } catch (e) {
-            openModal({
-                title: "Oopsie! ☹️",
-                message: ANSWER_VERIFICATION_MESSAGES.ERROR[props.challenge.type],
-                type: "error",
-                additionalDetails: e instanceof Error ? e.message + e.stack : "",
-            });
+            openModal(getErrorModal(ANSWER_VERIFICATION_MESSAGES.ERROR[props.challenge.type], e));
         }
 
         return false;

--- a/src/components/groups/welcome/WelcomeInput.tsx
+++ b/src/components/groups/welcome/WelcomeInput.tsx
@@ -5,6 +5,7 @@ import SubmitButton from "@/components/buttons/SubmitButton";
 import { useState } from "react";
 import { useModal } from "@/components/modals/Modal";
 import { User } from "@/classes/User/User";
+import { getErrorModal } from "@/constants/modal-templates";
 
 export default function WelcomeInput() {
     const [username, setUsername] = useState("");
@@ -17,13 +18,7 @@ export default function WelcomeInput() {
             await User.login(username);
             window.location.href = "/";
         } catch (error: unknown) {
-            openModal({
-                title: "Oh no! ☹️",
-                message: "There was an error logging in. Please try again later.",
-                type: "error",
-                additionalDetails: error instanceof Error ? error.stack : "",
-            });
-            return;
+            return openModal(getErrorModal("There was an error logging in. Please try again later.", error));
         } finally {
             setLoading(false);
         }

--- a/src/components/inputs/ImageUpload/ImageUploadHandler.tsx
+++ b/src/components/inputs/ImageUpload/ImageUploadHandler.tsx
@@ -3,6 +3,7 @@ import ImageUploadButton, { ImageUploadButtonSkeleton } from "@/components/input
 import React from "react";
 import { Image as ImageManager } from "@/classes/Image/Image";
 import { useModal } from "@/components/modals/Modal";
+import { getErrorModal } from "@/constants/modal-templates";
 
 type Props = {
     setLoading: (loading: boolean) => void;
@@ -29,12 +30,7 @@ export default function ImageUploadHandler(props: Props) {
             const url = await image.upload();
             props.setImage(url);
         } catch (error) {
-            openModal({
-                title: "Oh no! ☹️",
-                message: "There was an error uploading the image. Please try again later.",
-                type: "error",
-                additionalDetails: error instanceof Error ? error.stack : "",
-            });
+            return openModal(getErrorModal("There was an error uploading the image. Please try again later.", error));
         } finally {
             props.setLoading(false);
         }

--- a/src/constants/modal-templates.ts
+++ b/src/constants/modal-templates.ts
@@ -1,22 +1,25 @@
 import { OpenModalParams } from "@/components/modals/Modal";
 
-export const INVALID_CREDENTIALS_MODAL: OpenModalParams = {
-    title: "Oh no! ☹️",
-    message: "Invalid username and/or password. Please try again.",
-    type: "error",
-};
+export function getSuccessModal(message: string, redirectUrl?: string) {
+    const openModalParams: OpenModalParams = {
+        title: "Yay! 😄",
+        message: message,
+        type: "success",
+    };
 
-export const NOT_ADMIN_MODAL: OpenModalParams = {
-    title: "Oh no! ☹️",
-    message: "This user is not an admin. Try again with an admin account.",
-    type: "error",
-};
+    if (redirectUrl) openModalParams.closeAction = () => (window.location.href = "/admin/challenges");
+    return openModalParams;
+}
 
-export function getGenericErrorModal(error: Error | unknown): OpenModalParams {
+export function getErrorModal(message: string, error?: Error | unknown): OpenModalParams {
     return {
         title: "Oh no! ☹️",
-        message: "There was an unexpected error. Please try again.",
+        message: message,
         type: "error",
         additionalDetails: error instanceof Error ? error.stack : "",
     };
+}
+
+export function getGenericErrorModal(error: Error | unknown): OpenModalParams {
+    return getErrorModal("There was an unexpected error. Please try again.", error);
 }

--- a/src/hooks/AdminLoginFormHook.ts
+++ b/src/hooks/AdminLoginFormHook.ts
@@ -4,7 +4,7 @@ import { validatePassword, validateUsername } from "@/utils/validators";
 import { User } from "@/classes/User/User";
 import { NotAuthorizedError } from "@/errors/NotAuthorizedError";
 import { NotAdminError } from "@/errors/NotAdminError";
-import { getGenericErrorModal, INVALID_CREDENTIALS_MODAL, NOT_ADMIN_MODAL } from "@/constants/modal-templates";
+import { getErrorModal, getGenericErrorModal } from "@/constants/modal-templates";
 
 export default function useAdminLoginForm() {
     const { openModal } = useModal();
@@ -28,8 +28,12 @@ export default function useAdminLoginForm() {
             await User.adminLogin(values.username, values.password);
             window.location.href = "/admin";
         } catch (error: unknown) {
-            if (error instanceof NotAuthorizedError) return openModal(INVALID_CREDENTIALS_MODAL);
-            if (error instanceof NotAdminError) return openModal(NOT_ADMIN_MODAL);
+            if (error instanceof NotAuthorizedError)
+                return openModal(getErrorModal("Invalid username and/or password. Please try again."));
+
+            if (error instanceof NotAdminError)
+                return openModal(getErrorModal("This user is not an admin. Try again with an admin account"));
+
             return openModal(getGenericErrorModal(error));
         }
     };

--- a/src/hooks/CreateChallengeFormHook.ts
+++ b/src/hooks/CreateChallengeFormHook.ts
@@ -10,6 +10,7 @@ import {
 } from "@/utils/validators";
 import { ChallengeFactory } from "@/classes/Challenge/ChallengeFactory";
 import { useModal } from "@/components/modals/Modal";
+import { getErrorModal, getSuccessModal } from "@/constants/modal-templates";
 
 export default function useCreateChallengeForm() {
     const { openModal } = useModal();
@@ -39,19 +40,11 @@ export default function useCreateChallengeForm() {
         try {
             const values = form.getValues();
             await ChallengeFactory.create(values);
-            openModal({
-                title: "Success! 😄",
-                message: "Challenge created successfully!",
-                type: "success",
-                closeAction: () => (window.location.href = "/admin/challenges"),
-            });
+            return openModal(getSuccessModal("Challenge created successfully!", "/admin/challenges"));
         } catch (error) {
-            openModal({
-                title: "Oh no! ☹️",
-                message: "There was an error creating the challenge. Please try again later.",
-                type: "error",
-                additionalDetails: error instanceof Error ? error.stack : "",
-            });
+            return openModal(
+                getErrorModal("There was an error creating the challenge. Please try again later!", error),
+            );
         }
     };
 


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/25

This pull request refactors the modal logic across several components to use a new helper function for creating modals. This change simplifies the code and ensures consistency in modal creation and display.

Key changes include:

### Refactoring modal logic:

* [`src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx`](diffhunk://#diff-91aaee1e3cbdfa14f86085759e9814e9311fab74fbe9d040566ae09b4c53a633R10-R35): Replaced inline modal creation with the `getErrorModal` helper function for error messages and `getSuccessModal` for success messages.
* [`src/components/groups/welcome/WelcomeInput.tsx`](diffhunk://#diff-c48dc7a778dd14f6ed3fd596a467d8421d21eba09da96a810d6b81ff8257c8cfR8): Updated error handling to use `getErrorModal` for displaying login errors. [[1]](diffhunk://#diff-c48dc7a778dd14f6ed3fd596a467d8421d21eba09da96a810d6b81ff8257c8cfR8) [[2]](diffhunk://#diff-c48dc7a778dd14f6ed3fd596a467d8421d21eba09da96a810d6b81ff8257c8cfL20-R21)
* [`src/components/inputs/ImageUpload/ImageUploadHandler.tsx`](diffhunk://#diff-04270b5ae2aeabda16bbf82afe7e5dfe6886b4073f2d9c6e63419356396554a3R6): Simplified error handling by using `getErrorModal` for image upload errors. [[1]](diffhunk://#diff-04270b5ae2aeabda16bbf82afe7e5dfe6886b4073f2d9c6e63419356396554a3R6) [[2]](diffhunk://#diff-04270b5ae2aeabda16bbf82afe7e5dfe6886b4073f2d9c6e63419356396554a3L32-R33)

### Updating modal templates:

* [`src/constants/modal-templates.ts`](diffhunk://#diff-846642286928f459f085d97a610b6afb07cd5496fafdc2323eb8af8c8021d5e8L3-R25): Added `getErrorModal` and `getSuccessModal` helper functions to standardize modal creation. Removed old modal constants.

### Consistency in modal usage:

* [`src/hooks/AdminLoginFormHook.ts`](diffhunk://#diff-f78c25f55441778a24a4a50578d4dd0164dd115ed1d083a4b1ef8bec264c7c08L7-R7): Replaced specific modal constants with `getErrorModal` for login errors and unauthorized access errors. [[1]](diffhunk://#diff-f78c25f55441778a24a4a50578d4dd0164dd115ed1d083a4b1ef8bec264c7c08L7-R7) [[2]](diffhunk://#diff-f78c25f55441778a24a4a50578d4dd0164dd115ed1d083a4b1ef8bec264c7c08L31-R36)
* [`src/hooks/CreateChallengeFormHook.ts`](diffhunk://#diff-477d439413a475122f04a743ab261a45b47fb4be01a8dc14ccadbc0adccb4f83R13): Used `getSuccessModal` for successful challenge creation and `getErrorModal` for error handling. [[1]](diffhunk://#diff-477d439413a475122f04a743ab261a45b47fb4be01a8dc14ccadbc0adccb4f83R13) [[2]](diffhunk://#diff-477d439413a475122f04a743ab261a45b47fb4be01a8dc14ccadbc0adccb4f83L42-R47)