### PR TITLE
Add view for leaderboard

### DIFF
--- a/src/api/points/leaderboard/LeaderboardRequest.ts
+++ b/src/api/points/leaderboard/LeaderboardRequest.ts
@@ -1,0 +1,16 @@
+import { PrivilegedRequest } from "@/api/PrivilegedRequest";
+import { LeaderboardResponse } from "@/api/points/leaderboard/LeaderboardResponse";
+
+const ENDPOINT = "leaderboard";
+const METHOD = "GET";
+
+export class LeaderboardRequest extends PrivilegedRequest {
+    public constructor() {
+        super(ENDPOINT, METHOD);
+    }
+
+    public async send(): Promise<LeaderboardResponse> {
+        const response = (await super.send()) as LeaderboardResponse;
+        return new LeaderboardResponse(response);
+    }
+}

--- a/src/api/points/leaderboard/LeaderboardResponse.ts
+++ b/src/api/points/leaderboard/LeaderboardResponse.ts
@@ -1,0 +1,24 @@
+import { LeaderboardEntry } from "@/types/leaderboard-types";
+import { CannotProcessEntityError } from "@/errors/CannotProcessEntityError";
+
+export type LeaderboardResponseBody = {
+    leaderboard: LeaderboardEntry[];
+};
+
+export class LeaderboardResponse {
+    private readonly leaderboard: LeaderboardEntry[];
+
+    public constructor(data: LeaderboardResponse) {
+        this.leaderboard = data.leaderboard;
+        this.check();
+    }
+
+    public getLeaderboard(): LeaderboardEntry[] {
+        return this.leaderboard;
+    }
+
+    private check() {
+        if (this.leaderboard == null)
+            throw new CannotProcessEntityError("LeaderboardResponse", "leaderboard is missing");
+    }
+}

--- a/src/api/points/me/MyPointsResponse.ts
+++ b/src/api/points/me/MyPointsResponse.ts
@@ -1,3 +1,5 @@
+import { CannotProcessEntityError } from "@/errors/CannotProcessEntityError";
+
 export type MyPointsResponseBody = {
     points: number;
 };
@@ -6,7 +8,6 @@ export class MyPointsResponse {
     private readonly points: number;
 
     public constructor(data: MyPointsResponseBody) {
-        console.log("data", data.points);
         this.points = data.points;
         this.check();
     }
@@ -16,6 +17,6 @@ export class MyPointsResponse {
     }
 
     private check() {
-        // if (this.points == null) throw new CannotProcessEntityError("MyPointsResponse", "points is missing");
+        if (this.points == null) throw new CannotProcessEntityError("MyPointsResponse", "points is missing");
     }
 }

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,10 @@
+import HorizontallyCentered from "@/components/alignment/HorizontallyCentered";
+import Leaderboard from "@/components/groups/leaderboard/Leaderboard";
+
+export default function Welcome() {
+    return (
+        <HorizontallyCentered>
+            <Leaderboard />
+        </HorizontallyCentered>
+    );
+}

--- a/src/components/groups/leaderboard/Leaderboard.tsx
+++ b/src/components/groups/leaderboard/Leaderboard.tsx
@@ -3,16 +3,31 @@
 import useLeaderboard from "@/hooks/LeaderboardHook";
 import { Card } from "@mantine/core";
 import LeaderboardHeader from "@/components/groups/leaderboard/LeaderboardHeader";
-import LeaderboardTable from "@/components/groups/leaderboard/LeaderboardTable";
+import LeaderboardTable, { LeaderboardTableSkeleton } from "@/components/groups/leaderboard/LeaderboardTable";
+import AnimationFade from "@/components/framer-motion/AnimationFade";
+import AnimationWrapper from "@/components/framer-motion/AnimationWrapper";
 
 export default function Leaderboard() {
     const { leaderboard, loading } = useLeaderboard();
+
     return (
-        <Card shadow={"md"} padding="lg" radius="md" withBorder>
-            <div className={`flex flex-col space-y-5 min-w-[500px]`}>
+        <Card shadow={"md"} padding="lg" radius="md" withBorder className={`min-w-[500px] sm:w-full sm:min-w-full`}>
+            <div className={`flex flex-col space-y-5`}>
                 <LeaderboardHeader />
 
-                {leaderboard && !loading && <LeaderboardTable leaderboard={leaderboard} />}
+                <AnimationWrapper>
+                    {leaderboard && !loading && (
+                        <AnimationFade key={"loaded"}>
+                            <LeaderboardTable leaderboard={leaderboard} />
+                        </AnimationFade>
+                    )}
+
+                    {loading && (
+                        <AnimationFade key={"loading"}>
+                            <LeaderboardTableSkeleton />
+                        </AnimationFade>
+                    )}
+                </AnimationWrapper>
             </div>
         </Card>
     );

--- a/src/components/groups/leaderboard/Leaderboard.tsx
+++ b/src/components/groups/leaderboard/Leaderboard.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import useLeaderboard from "@/hooks/LeaderboardHook";
+import { Card } from "@mantine/core";
+import LeaderboardHeader from "@/components/groups/leaderboard/LeaderboardHeader";
+import LeaderboardTable from "@/components/groups/leaderboard/LeaderboardTable";
+
+export default function Leaderboard() {
+    const { leaderboard, loading } = useLeaderboard();
+    return (
+        <Card shadow={"md"} padding="lg" radius="md" withBorder>
+            <div className={`flex flex-col space-y-5 min-w-[500px]`}>
+                <LeaderboardHeader />
+
+                {leaderboard && !loading && <LeaderboardTable leaderboard={leaderboard} />}
+            </div>
+        </Card>
+    );
+}

--- a/src/components/groups/leaderboard/LeaderboardHeader.tsx
+++ b/src/components/groups/leaderboard/LeaderboardHeader.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import TitleText from "@/components/text/TitleText";
+import SmallText from "@/components/text/SmallText";
+
+export default function LeaderboardHeader() {
+    return (
+        <div>
+            <TitleText>Leaderboard</TitleText>
+            <SmallText>See where you rank!</SmallText>
+        </div>
+    );
+}

--- a/src/components/groups/leaderboard/LeaderboardTable.tsx
+++ b/src/components/groups/leaderboard/LeaderboardTable.tsx
@@ -2,8 +2,7 @@
 
 import { Table } from "@mantine/core";
 import { LeaderboardEntry } from "@/types/leaderboard-types";
-import SmallText from "@/components/text/SmallText";
-import HorizontallyCentered from "@/components/alignment/HorizontallyCentered";
+import { generateRows, generateSkeletonRows } from "@/components/groups/leaderboard/LeaderboardTableGenerators";
 
 export type Props = {
     leaderboard: LeaderboardEntry[];
@@ -14,8 +13,8 @@ export default function LeaderboardTable(props: Props) {
         <Table highlightOnHover>
             <Table.Thead>
                 <Table.Tr>
-                    <Table.Th w={75}></Table.Th>
-                    <Table.Th w={300}>Name</Table.Th>
+                    <Table.Th w={50}></Table.Th>
+                    <Table.Th>Name</Table.Th>
                     <Table.Th>
                         <div className={`text-right`}>Points</div>
                     </Table.Th>
@@ -27,45 +26,20 @@ export default function LeaderboardTable(props: Props) {
     );
 }
 
-function generateRows(leaderBoard: LeaderboardEntry[]) {
-    if (leaderBoard.length === 0) {
-        return (
-            <Table.Tr>
-                <Table.Td colSpan={3}>
-                    <HorizontallyCentered>
-                        <SmallText>No one has completed any challenges yet</SmallText>
-                    </HorizontallyCentered>
-                </Table.Td>
-            </Table.Tr>
-        );
-    }
-
-    return leaderBoard.map((user, index) => (
-        <Table.Tr key={index}>
-            <Table.Td>{getRankCell(index + 1)}</Table.Td>
-            <Table.Td>{user.username}</Table.Td>
-            <Table.Td align={"right"}>{user.points.toLocaleString()}</Table.Td>
-        </Table.Tr>
-    ));
-}
-
-function getRankCell(rank: number) {
-    if (rank === 1) {
-        return getRankBox(1, "🥇");
-    } else if (rank === 2) {
-        return getRankBox(2, "🥈");
-    } else if (rank === 3) {
-        return getRankBox(3, "🥉");
-    }
-
-    return getRankBox(rank, "");
-}
-
-function getRankBox(rank: number, prefix: string) {
+export function LeaderboardTableSkeleton() {
     return (
-        <div className={`flex flex-row space-x-2`}>
-            <div className={`w-5`}>{prefix}</div>
-            <div>{rank}</div>
-        </div>
+        <Table highlightOnHover>
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th w={50}></Table.Th>
+                    <Table.Th>Name</Table.Th>
+                    <Table.Th>
+                        <div className={`text-right`}>Points</div>
+                    </Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+
+            <Table.Tbody>{generateSkeletonRows()}</Table.Tbody>
+        </Table>
     );
 }

--- a/src/components/groups/leaderboard/LeaderboardTable.tsx
+++ b/src/components/groups/leaderboard/LeaderboardTable.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Table } from "@mantine/core";
+import { LeaderboardEntry } from "@/types/leaderboard-types";
+import SmallText from "@/components/text/SmallText";
+import HorizontallyCentered from "@/components/alignment/HorizontallyCentered";
+
+export type Props = {
+    leaderboard: LeaderboardEntry[];
+};
+
+export default function LeaderboardTable(props: Props) {
+    return (
+        <Table highlightOnHover>
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th w={75}></Table.Th>
+                    <Table.Th w={300}>Name</Table.Th>
+                    <Table.Th>
+                        <div className={`text-right`}>Points</div>
+                    </Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+
+            <Table.Tbody>{generateRows(props.leaderboard)}</Table.Tbody>
+        </Table>
+    );
+}
+
+function generateRows(leaderBoard: LeaderboardEntry[]) {
+    if (leaderBoard.length === 0) {
+        return (
+            <Table.Tr>
+                <Table.Td colSpan={3}>
+                    <HorizontallyCentered>
+                        <SmallText>No one has completed any challenges yet</SmallText>
+                    </HorizontallyCentered>
+                </Table.Td>
+            </Table.Tr>
+        );
+    }
+
+    return leaderBoard.map((user, index) => (
+        <Table.Tr key={index}>
+            <Table.Td>{getRankCell(index + 1)}</Table.Td>
+            <Table.Td>{user.username}</Table.Td>
+            <Table.Td align={"right"}>{user.points.toLocaleString()}</Table.Td>
+        </Table.Tr>
+    ));
+}
+
+function getRankCell(rank: number) {
+    if (rank === 1) {
+        return getRankBox(1, "🥇");
+    } else if (rank === 2) {
+        return getRankBox(2, "🥈");
+    } else if (rank === 3) {
+        return getRankBox(3, "🥉");
+    }
+
+    return getRankBox(rank, "");
+}
+
+function getRankBox(rank: number, prefix: string) {
+    return (
+        <div className={`flex flex-row space-x-2`}>
+            <div className={`w-5`}>{prefix}</div>
+            <div>{rank}</div>
+        </div>
+    );
+}

--- a/src/components/groups/leaderboard/LeaderboardTableGenerators.tsx
+++ b/src/components/groups/leaderboard/LeaderboardTableGenerators.tsx
@@ -1,0 +1,62 @@
+import { LeaderboardEntry } from "@/types/leaderboard-types";
+import { Table } from "@mantine/core";
+import HorizontallyCentered from "@/components/alignment/HorizontallyCentered";
+import SmallText, { SmallTextSkeleton } from "@/components/text/SmallText";
+
+export function generateRows(leaderBoard: LeaderboardEntry[]) {
+    if (leaderBoard.length === 0) {
+        return (
+            <Table.Tr>
+                <Table.Td colSpan={3}>
+                    <HorizontallyCentered>
+                        <SmallText>No one has completed any challenges yet</SmallText>
+                    </HorizontallyCentered>
+                </Table.Td>
+            </Table.Tr>
+        );
+    }
+
+    return leaderBoard.map((user, index) => (
+        <Table.Tr key={index}>
+            <Table.Td>{getRankCell(index + 1)}</Table.Td>
+            <Table.Td>{user.username}</Table.Td>
+            <Table.Td align={"right"}>{user.points.toLocaleString()}</Table.Td>
+        </Table.Tr>
+    ));
+}
+
+function getRankCell(rank: number) {
+    if (rank === 1) {
+        return getRankBox("🥇");
+    } else if (rank === 2) {
+        return getRankBox("🥈");
+    } else if (rank === 3) {
+        return getRankBox("🥉");
+    }
+
+    return getRankBox(rank.toString());
+}
+
+function getRankBox(rank: string) {
+    return (
+        <div className={`flex flex-row space-x-2`}>
+            <div className={`w-5 text-center`}>{rank}</div>
+        </div>
+    );
+}
+
+export function generateSkeletonRows() {
+    return Array.from({ length: 10 }).map((_, index) => (
+        <Table.Tr key={index}>
+            <Table.Td>
+                <SmallTextSkeleton w={"100%"} />
+            </Table.Td>
+            <Table.Td>
+                <SmallTextSkeleton w={"50%"} />
+            </Table.Td>
+            <Table.Td align={"right"}>
+                <SmallTextSkeleton w={"30%"} />
+            </Table.Td>
+        </Table.Tr>
+    ));
+}

--- a/src/hooks/LeaderboardHook.ts
+++ b/src/hooks/LeaderboardHook.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { useModal } from "@/components/modals/Modal";
+import { getGenericErrorModal } from "@/constants/modal-templates";
+import { LeaderboardRequest } from "@/api/points/leaderboard/LeaderboardRequest";
+import { LeaderboardEntry } from "@/types/leaderboard-types";
+
+export default function useLeaderboard() {
+    const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[] | null>(null);
+    const [loading, setLoading] = useState(true);
+    const { openModal } = useModal();
+
+    async function fetchLeaderboard() {
+        setLoading(true);
+        try {
+            const request = new LeaderboardRequest();
+            const response = await request.send();
+            setLeaderboard(response.getLeaderboard());
+        } catch (error) {
+            openModal(getGenericErrorModal(error));
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        fetchLeaderboard();
+    }, []);
+
+    return {
+        leaderboard,
+        loading,
+    };
+}

--- a/src/types/leaderboard-types.ts
+++ b/src/types/leaderboard-types.ts
@@ -1,0 +1,4 @@
+export type LeaderboardEntry = {
+    username: string;
+    points: number;
+};


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/29

This pull request introduces a new leaderboard feature, including the necessary API requests and responses, UI components, and hooks for fetching and displaying leaderboard data. The most important changes are summarized below:

### API Implementation:
* [`src/api/points/leaderboard/LeaderboardRequest.ts`](diffhunk://#diff-cdb3ef60addfdb2645ff979c05c3428bbb573d4d00552bd559ac010eaf6b04ddR1-R16): Created `LeaderboardRequest` class to handle the API request for fetching the leaderboard data.
* [`src/api/points/leaderboard/LeaderboardResponse.ts`](diffhunk://#diff-05b275c0890d588527637ce55f9ce9b78c3ef4980986dc7449736d69c122a7a0R1-R24): Added `LeaderboardResponse` class to process and validate the leaderboard data received from the API.

### UI Components:
* [`src/app/leaderboard/page.tsx`](diffhunk://#diff-b1a19a4e637bbf289d5fc6edc5a2d6c9ae7f83f2aa13eb914bfd492444003377R1-R10): Added a new page component to display the leaderboard using the `Leaderboard` component.
* [`src/components/groups/leaderboard/Leaderboard.tsx`](diffhunk://#diff-acc35cdd6434b2aaeb6f6450654eed0ca8b713ba0839b463ddc215b686d99dcbR1-R34): Implemented the main `Leaderboard` component, which uses `LeaderboardHeader` and `LeaderboardTable` to display the leaderboard data.
* [`src/components/groups/leaderboard/LeaderboardHeader.tsx`](diffhunk://#diff-ef923c917ac8383a05daa9c6ea85ae6df0826ccabba8699915c77def4bf200a4R1-R13): Created `LeaderboardHeader` component to display the title and description of the leaderboard.
* [`src/components/groups/leaderboard/LeaderboardTable.tsx`](diffhunk://#diff-9b86153ec5bb228ea5ab7a76be961461ed1030a3b0100f461cfe9f461e90d01bR1-R45): Developed `LeaderboardTable` and `LeaderboardTableSkeleton` components to display the leaderboard entries and loading state.
* [`src/components/groups/leaderboard/LeaderboardTableGenerators.tsx`](diffhunk://#diff-b3146f5004b99924a97e5d2f11480de70cc2af2a7b56e3cbef6c153013697325R1-R62): Added utility functions to generate rows for the leaderboard table and skeleton.

### Hooks:
* [`src/hooks/LeaderboardHook.ts`](diffhunk://#diff-cde64bbe686ccbc8c62d1f566048a4de437d942fb9f7c86efb9a6235c7760dc9R1-R33): Implemented `useLeaderboard` hook to fetch and manage the leaderboard data state.

### Types:
* [`src/types/leaderboard-types.ts`](diffhunk://#diff-ec8afb5e16af01120580585be14ea6e71b9a922fdd7fa3fb69b6877e12653a15R1-R4): Defined `LeaderboardEntry` type to represent individual leaderboard entries.

### Error Handling:
* [`src/api/points/me/MyPointsResponse.ts`](diffhunk://#diff-7e2ee28bae6df65d6837b0cd9b4f017b982e932baf25d1e5e663e457201fdb9bR1-R2): Updated error handling in `MyPointsResponse` class by removing console log and uncommenting the error throw statement. [[1]](diffhunk://#diff-7e2ee28bae6df65d6837b0cd9b4f017b982e932baf25d1e5e663e457201fdb9bR1-R2) [[2]](diffhunk://#diff-7e2ee28bae6df65d6837b0cd9b4f017b982e932baf25d1e5e663e457201fdb9bL9) [[3]](diffhunk://#diff-7e2ee28bae6df65d6837b0cd9b4f017b982e932baf25d1e5e663e457201fdb9bL19-R20)