### PR TITLE
Add CI configuration for pull requests and workflow dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  ci:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build --if-present


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/43

This pull request introduces a new Continuous Integration (CI) workflow to the project. The workflow is defined in a new file `.github/workflows/ci.yaml` and includes steps for checking out the code, setting up Node.js, installing dependencies, and building the project.

Key changes:

* Added a new CI workflow configuration in `.github/workflows/ci.yaml` to automate the build process on pull requests to the `main` branch.
* The workflow includes steps to checkout the code, set up Node.js version 20.x, install dependencies using `npm ci`, and run the build script if present.