### PR TITLE
Add navigation menu for mobile

### DIFF
--- a/src/components/groups/header/Header.tsx
+++ b/src/components/groups/header/Header.tsx
@@ -1,11 +1,15 @@
 import HeaderLinks from "@/components/groups/header/HeaderLinks";
 import HeaderTagline from "@/components/groups/header/HeaderTagline";
+import HeaderMenu from "@/components/groups/header/HeaderMenu";
 
 export default function Header() {
     return (
         <div className={`flex flex-row justify-center items-center bg-slate-800 p-5 border-b-2 border-b-gray-500`}>
             <div className={`flex w-[1200px] justify-between items-center`}>
-                <HeaderTagline />
+                <div className={`flex flex-row items-center space-x-5`}>
+                    <HeaderMenu />
+                    <HeaderTagline />
+                </div>
                 <div className={`sm:hidden`}>
                     <HeaderLinks />
                 </div>

--- a/src/components/groups/header/HeaderMenu.tsx
+++ b/src/components/groups/header/HeaderMenu.tsx
@@ -30,7 +30,7 @@ export default function HeaderMenu() {
         <Menu
             shadow="md"
             width={200}
-            trigger="hover"
+            trigger="click"
             transitionProps={{ transition: "scale-y", duration: 100, timingFunction: "ease" }}
         >
             <Menu.Target>

--- a/src/components/groups/header/HeaderMenu.tsx
+++ b/src/components/groups/header/HeaderMenu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Menu } from "@mantine/core";
+import { IconChartBar, IconChecklist, IconHelpCircle, IconLibraryPhoto } from "@tabler/icons-react";
+import HamburgerMenuIcon from "@/components/icons/HamburgerMenuIcon";
+import { useUser } from "@/classes/User/UserHook";
+import Link from "next/link";
+
+type MenuItem = {
+    label: string;
+    icon: React.ReactNode;
+    link: string;
+};
+
+const PLAYER_MENU_ITEMS: MenuItem[] = [
+    { label: "Instructions", icon: <IconHelpCircle size={14} />, link: "/instructions" },
+    { label: "Challenges", icon: <IconChecklist size={14} />, link: "/" },
+    { label: "Gallery", icon: <IconLibraryPhoto size={14} />, link: "/gallery" },
+    { label: "Leaderboard", icon: <IconChartBar size={14} />, link: "/leaderboard" },
+];
+
+const ADMIN_MENU_ITEMS: MenuItem[] = [
+    { label: "Challenges", icon: <IconChecklist size={14} />, link: "/admin/challenges" },
+];
+
+export default function HeaderMenu() {
+    const { user, loading } = useUser();
+
+    return (
+        <Menu
+            shadow="md"
+            width={200}
+            trigger="hover"
+            transitionProps={{ transition: "scale-y", duration: 100, timingFunction: "ease" }}
+        >
+            <Menu.Target>
+                <div className={`w-5 text-white cursor-pointer hover:text-gray-300`}>
+                    <HamburgerMenuIcon />
+                </div>
+            </Menu.Target>
+
+            <Menu.Dropdown>
+                <Menu.Label>The Wedding Game</Menu.Label>
+                {PLAYER_MENU_ITEMS.map((item) => (
+                    <Menu.Item key={item.label} leftSection={item.icon} component={Link} href={item.link}>
+                        {item.label}
+                    </Menu.Item>
+                ))}
+
+                {!loading && user?.isAdmin() && (
+                    <>
+                        <Menu.Divider />
+                        <Menu.Label>Administrator</Menu.Label>
+
+                        {ADMIN_MENU_ITEMS.map((item) => (
+                            <Menu.Item key={item.label} leftSection={item.icon} component={Link} href={item.link}>
+                                {item.label}
+                            </Menu.Item>
+                        ))}
+                    </>
+                )}
+            </Menu.Dropdown>
+        </Menu>
+    );
+}

--- a/src/components/icons/HamburgerMenuIcon.tsx
+++ b/src/components/icons/HamburgerMenuIcon.tsx
@@ -1,0 +1,19 @@
+export default function HamburgerMenuIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="icon icon-tabler icons-tabler-outline icon-tabler-menu-2"
+        >
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path d="M4 6l16 0" />
+            <path d="M4 12l16 0" />
+            <path d="M4 18l16 0" />
+        </svg>
+    );
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/53

This pull request introduces a new `HeaderMenu` component to the header section of the application, enhancing the navigation experience for both players and administrators. The key changes include the addition of the `HeaderMenu` component, the creation of the `HamburgerMenuIcon` component, and the integration of these components into the existing header structure.

New components:

* [`src/components/groups/header/HeaderMenu.tsx`](diffhunk://#diff-dda444e1849dd63ea27d5f8bb4a98e8f103cad113c38a129c48af3f1badeb3f6R1-R65): Introduced a new `HeaderMenu` component that provides a dropdown menu with navigation links for players and administrators. The menu items are conditionally rendered based on the user's admin status.
* [`src/components/icons/HamburgerMenuIcon.tsx`](diffhunk://#diff-3d76bb748e3c2166041bc83f74e057bc1fc0cf3fbe21fa3f8008611519df4b4eR1-R19): Created a new `HamburgerMenuIcon` component to be used as the trigger icon for the `HeaderMenu` dropdown.

Integration into header:

* [`src/components/groups/header/Header.tsx`](diffhunk://#diff-1a1c5ac9a2761a3dc84e05b1ae7899d9199b6b1a12cc44ee7634214cc482d4b7R3-R12): Updated the `Header` component to include the new `HeaderMenu` component, positioning it alongside the `HeaderTagline` component.