### PR TITLE
Refactor navigation links to use Next.js Link component and useRouter

### DIFF
--- a/src/classes/User/UserHook.ts
+++ b/src/classes/User/UserHook.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { User } from "@/classes/User/User";
 import { UserFactory } from "@/classes/User/UserFactory";
+import { useRouter } from "next/navigation";
 
 export function useUser() {
     const [user, setUser] = useState<User | null>(null);
     const [loading, setLoading] = useState(true);
+    const router = useRouter();
 
     useEffect(() => {
         setLoading(true);
@@ -14,7 +16,7 @@ export function useUser() {
             })
             .catch(() => {
                 setUser(null);
-                window.location.href = "/welcome";
+                router.push("/welcome");
             })
             .finally(() => {
                 setLoading(false);

--- a/src/components/buttons/AdminLoginButton.tsx
+++ b/src/components/buttons/AdminLoginButton.tsx
@@ -1,14 +1,15 @@
 import { Button } from "@mantine/core";
+import Link from "next/link";
 
 export default function AdminLoginButton() {
     return (
-        <a href={`/auth/admin`}>
+        <Link href={`/auth/admin`}>
             <Button color="blue" fullWidth radius="sm" {...dimensions}>
                 <div className={`flex flex-row items-center space-x-2`}>
                     <div>Log in as admin</div>
                 </div>
             </Button>
-        </a>
+        </Link>
     );
 }
 

--- a/src/components/buttons/CreateChallengeButton.tsx
+++ b/src/components/buttons/CreateChallengeButton.tsx
@@ -1,9 +1,10 @@
 import { Button, Skeleton } from "@mantine/core";
 import CreateIcon from "@/components/icons/CreateIcon";
+import Link from "next/link";
 
 export default function CreateChallengeButton() {
     return (
-        <a href={`/admin/challenges/create`}>
+        <Link href={`/admin/challenges/create`}>
             <Button color="blue" fullWidth radius="sm" {...dimensions}>
                 <div className={`flex flex-row items-center space-x-2`}>
                     <div className={`w-6`}>
@@ -12,7 +13,7 @@ export default function CreateChallengeButton() {
                     <div>Create New Challenge</div>
                 </div>
             </Button>
-        </a>
+        </Link>
     );
 }
 

--- a/src/components/buttons/FooterLinkButton.tsx
+++ b/src/components/buttons/FooterLinkButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@mantine/core";
 import { ReactNode } from "react";
+import Link from "next/link";
 
 type Props = {
     text: string;
@@ -8,13 +9,13 @@ type Props = {
 };
 export default function FooterLinkButton(props: Props) {
     return (
-        <a href={props.link} target={"_blank"}>
+        <Link href={props.link} target={"_blank"}>
             <Button variant={"outline"} color={"black"} radius="sm" size={"sm"}>
                 <div className={`flex flex-row items-center space-x-2`}>
                     {props.icon && <div className={`w-4`}>{props.icon}</div>}
                     <div>{props.text}</div>
                 </div>
             </Button>
-        </a>
+        </Link>
     );
 }

--- a/src/components/buttons/HeaderLinkButton.tsx
+++ b/src/components/buttons/HeaderLinkButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@mantine/core";
+import Link from "next/link";
 
 type Props = {
     text: string;
@@ -6,10 +7,10 @@ type Props = {
 };
 export default function HeaderLinkButton(props: Props) {
     return (
-        <a href={props.link}>
+        <Link href={props.link}>
             <Button variant={"outline"} color={"white"} radius="sm" size={"sm"}>
                 {props.text}
             </Button>
-        </a>
+        </Link>
     );
 }

--- a/src/components/buttons/LinkButton.tsx
+++ b/src/components/buttons/LinkButton.tsx
@@ -1,4 +1,5 @@
 import { Button, MantineColor, Skeleton } from "@mantine/core";
+import Link from "next/link";
 import { ReactNode } from "react";
 
 type Props = {
@@ -10,14 +11,14 @@ type Props = {
 
 export default function LinkButton(props: Props) {
     return (
-        <a href={props.link}>
+        <Link href={props.link}>
             <Button variant={"outline"} color={props.color} size={"xs"} fullWidth radius="sm" {...dimensions}>
                 <div className={`flex flex-row items-center space-x-2`}>
                     {props.icon && <div className={`w-4`}>{props.icon}</div>}
                     <div>{props.children}</div>
                 </div>
             </Button>
-        </a>
+        </Link>
     );
 }
 

--- a/src/components/groups/challenge/challenge-card/ChallengeCard.tsx
+++ b/src/components/groups/challenge/challenge-card/ChallengeCard.tsx
@@ -6,6 +6,7 @@ import ChallengeCardContent, {
 import ChallengeCardImage, {
     ChallengeCardImageSkeleton,
 } from "@/components/groups/challenge/challenge-card/ChallengeCardImage";
+import Link from "next/link";
 
 type Props = {
     challenge: Challenge;
@@ -16,14 +17,14 @@ export default function ChallengeCard(props: Props) {
 
     return (
         <Card shadow="sm" padding="0" radius="md" withBorder className={`max-w-96 w-full`}>
-            <a href={`/challenge/${props.challenge.id}`}>
+            <Link href={`/challenge/${props.challenge.id}`}>
                 <div className={`flex flex-col sm:flex-row sm:space-x-2`}>
                     <div className={`sm:w-1/2 h-full`}>
                         <ChallengeCardImage challenge={challenge} />
                     </div>
                     <ChallengeCardContent challenge={challenge} />
                 </div>
-            </a>
+            </Link>
         </Card>
     );
 }

--- a/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
+++ b/src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx
@@ -8,6 +8,7 @@ import SubmitPhotoSubmission, {
     SubmitPhotoSubmissionSkeleton,
 } from "@/components/forms/submit-photo/SubmitPhotoSubmission";
 import { getErrorModal, getSuccessModal } from "@/constants/modal-templates";
+import { useRouter } from "next/navigation";
 
 type Props = {
     challenge: Challenge;
@@ -15,6 +16,7 @@ type Props = {
 
 export default function ChallengeSubmissionGroup(props: Props) {
     const { openModal } = useModal();
+    const router = useRouter();
 
     async function submitAnswer(answer: string | null): Promise<boolean> {
         if (!answer) {
@@ -25,7 +27,11 @@ export default function ChallengeSubmissionGroup(props: Props) {
         const answerObj = new Answer(props.challenge.id, answer);
         try {
             if (await answerObj.verify()) {
-                openModal(getSuccessModal(ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type], "/"));
+                openModal(
+                    getSuccessModal(ANSWER_VERIFICATION_MESSAGES.SUCCESS[props.challenge.type], () => {
+                        router.push("/");
+                    }),
+                );
                 return true;
             } else {
                 openModal(getErrorModal(ANSWER_VERIFICATION_MESSAGES.FAILURE[props.challenge.type]));

--- a/src/components/groups/welcome/WelcomeInput.tsx
+++ b/src/components/groups/welcome/WelcomeInput.tsx
@@ -6,17 +6,19 @@ import { useState } from "react";
 import { useModal } from "@/components/modals/Modal";
 import { User } from "@/classes/User/User";
 import { getErrorModal } from "@/constants/modal-templates";
+import { useRouter } from "next/navigation";
 
 export default function WelcomeInput() {
     const [username, setUsername] = useState("");
     const [loading, setLoading] = useState(false);
     const { openModal } = useModal();
+    const router = useRouter();
 
     async function submit() {
         setLoading(true);
         try {
             await User.login(username);
-            window.location.href = "/";
+            router.push("/");
         } catch (error: unknown) {
             return openModal(getErrorModal("There was an error logging in. Please try again later.", error));
         } finally {

--- a/src/constants/modal-templates.ts
+++ b/src/constants/modal-templates.ts
@@ -1,13 +1,13 @@
 import { OpenModalParams } from "@/components/modals/Modal";
 
-export function getSuccessModal(message: string, redirectUrl?: string) {
+export function getSuccessModal(message: string, redirection?: () => void): OpenModalParams {
     const openModalParams: OpenModalParams = {
         title: "Yay! 😄",
         message: message,
         type: "success",
     };
 
-    if (redirectUrl) openModalParams.closeAction = () => (window.location.href = redirectUrl);
+    if (redirection) openModalParams.closeAction = () => redirection();
     return openModalParams;
 }
 

--- a/src/hooks/AdminLoginFormHook.ts
+++ b/src/hooks/AdminLoginFormHook.ts
@@ -5,9 +5,11 @@ import { User } from "@/classes/User/User";
 import { NotAuthorizedError } from "@/errors/NotAuthorizedError";
 import { NotAdminError } from "@/errors/NotAdminError";
 import { getErrorModal, getGenericErrorModal } from "@/constants/modal-templates";
+import { useRouter } from "next/navigation";
 
 export default function useAdminLoginForm() {
     const { openModal } = useModal();
+    const router = useRouter();
 
     const form = useForm({
         mode: "uncontrolled",
@@ -26,7 +28,7 @@ export default function useAdminLoginForm() {
         try {
             const values = form.getValues();
             await User.adminLogin(values.username, values.password);
-            window.location.href = "/admin";
+            router.push("/admin");
         } catch (error: unknown) {
             if (error instanceof NotAuthorizedError)
                 return openModal(getErrorModal("Invalid username and/or password. Please try again."));

--- a/src/hooks/CreateChallengeFormHook.ts
+++ b/src/hooks/CreateChallengeFormHook.ts
@@ -11,9 +11,11 @@ import {
 import { ChallengeFactory } from "@/classes/Challenge/ChallengeFactory";
 import { useModal } from "@/components/modals/Modal";
 import { getErrorModal, getSuccessModal } from "@/constants/modal-templates";
+import { useRouter } from "next/navigation";
 
 export default function useCreateChallengeForm() {
     const { openModal } = useModal();
+    const router = useRouter();
 
     const form = useForm({
         mode: "uncontrolled",
@@ -40,7 +42,9 @@ export default function useCreateChallengeForm() {
         try {
             const values = form.getValues();
             await ChallengeFactory.create(values);
-            return openModal(getSuccessModal("Challenge created successfully!", "/admin/challenges"));
+            return openModal(
+                getSuccessModal("Challenge created successfully!", () => router.push("/admin/challenges")),
+            );
         } catch (error) {
             return openModal(
                 getErrorModal("There was an error creating the challenge. Please try again later!", error),

--- a/src/hooks/CreateOrEditChallengeFormHook.ts
+++ b/src/hooks/CreateOrEditChallengeFormHook.ts
@@ -13,9 +13,11 @@ import { getErrorModal, getSuccessModal } from "@/constants/modal-templates";
 import { Challenge } from "@/classes/Challenge/Challenge";
 import { CHALLENGE_TYPES, ChallengeType } from "@/classes/Challenge/ChallengeTypes";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function useCreateOrEditChallengeForm(challenge: Challenge) {
     const { openModal } = useModal();
+    const router = useRouter();
 
     const form = useForm({
         mode: "uncontrolled",
@@ -77,13 +79,13 @@ export default function useCreateOrEditChallengeForm(challenge: Challenge) {
         if (values.answer) challenge.answer = values.answer;
 
         await challenge.update();
-        return openModal(getSuccessModal("Challenge updated successfully!", "/admin/challenges"));
+        return openModal(getSuccessModal("Challenge updated successfully!", () => router.push("/admin/challenges")));
     };
 
     const createChallenge = async function () {
         const values = form.getValues();
         await ChallengeFactory.create(values);
-        return openModal(getSuccessModal("Challenge created successfully!", "/admin/challenges"));
+        return openModal(getSuccessModal("Challenge created successfully!", () => router.push("/admin/challenges")));
     };
 
     return {


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/61

This pull request includes several changes to improve the navigation experience across the application by replacing direct URL manipulations with the `next/link` and `next/navigation` modules. The most important changes include updating various button components and hooks to use these modules for navigation.

### Navigation Improvements:

* [`src/classes/User/UserHook.ts`](diffhunk://#diff-ad8a0c1988ecfa50de49a88fe15b9cbe3ae04839c173ac8641436de030bd666cL17-R19): Replaced `window.location.href` with `router.push` for navigation to the welcome page upon user login failure.
* [`src/components/buttons/AdminLoginButton.tsx`](diffhunk://#diff-466e4e68784a4a5ba6105482c045fd3715cc8ffa7538dc65d745b6fa3c01a147R2-R12): Updated the admin login button to use `Link` from `next/link` instead of an anchor tag for navigation.
* [`src/components/buttons/CreateChallengeButton.tsx`](diffhunk://#diff-ae89b31b88d1fde37a9c8152b9a9fafef23c86905d764b35dfddfe312c799276R3-R7): Updated the create challenge button to use `Link` from `next/link` instead of an anchor tag for navigation. [[1]](diffhunk://#diff-ae89b31b88d1fde37a9c8152b9a9fafef23c86905d764b35dfddfe312c799276R3-R7) [[2]](diffhunk://#diff-ae89b31b88d1fde37a9c8152b9a9fafef23c86905d764b35dfddfe312c799276L15-R16)
* [`src/components/groups/challenge/challenge-page/ChallengeSubmissionGroup.tsx`](diffhunk://#diff-91aaee1e3cbdfa14f86085759e9814e9311fab74fbe9d040566ae09b4c53a633L28-R34): Modified the success modal to use `router.push` for redirection after successful answer verification.
* [`src/constants/modal-templates.ts`](diffhunk://#diff-846642286928f459f085d97a610b6afb07cd5496fafdc2323eb8af8c8021d5e8L3-R10): Changed the `getSuccessModal` function to accept a redirection callback instead of a URL string, enabling more flexible navigation handling.