### PR TITLE
Add loading skeleton for edit challenge view

### DIFF
--- a/src/app/admin/challenges/[id]/edit/page.tsx
+++ b/src/app/admin/challenges/[id]/edit/page.tsx
@@ -4,13 +4,15 @@ import { useUser } from "@/classes/User/UserHook";
 import { Card } from "@mantine/core";
 import HorizontallyCentered from "@/components/alignment/HorizontallyCentered";
 import { useParams } from "next/navigation";
-import EditChallengeFormOuter from "@/components/forms/edit-challenge/EditChallengeFormOuter";
+import EditChallengeFormOuter, {
+    EditChallengeFormOuterSkeleton,
+} from "@/components/forms/edit-challenge/EditChallengeFormOuter";
 import { useChallenge } from "@/classes/Challenge/ChallengeHook";
 
 export default function CreateChallenge() {
     useUser();
     const challengeId = useParams<{ id: string }>().id;
-    const { challenge } = useChallenge(parseInt(challengeId));
+    const { challenge, loading } = useChallenge(parseInt(challengeId));
 
     return (
         <>
@@ -18,6 +20,14 @@ export default function CreateChallenge() {
                 <HorizontallyCentered>
                     <Card shadow="sm" padding="lg" radius="md" withBorder className={`max-w-96 w-full`}>
                         <EditChallengeFormOuter challenge={challenge} />
+                    </Card>
+                </HorizontallyCentered>
+            )}
+
+            {loading && (
+                <HorizontallyCentered>
+                    <Card shadow="sm" padding="lg" radius="md" withBorder className={`max-w-96 w-full`}>
+                        <EditChallengeFormOuterSkeleton />
                     </Card>
                 </HorizontallyCentered>
             )}

--- a/src/components/forms/edit-challenge/EditChallengeFormInner.tsx
+++ b/src/components/forms/edit-challenge/EditChallengeFormInner.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { NativeSelect, NumberInput, Textarea, TextInput } from "@mantine/core";
+import { NativeSelect, NumberInput, Skeleton, Textarea, TextInput } from "@mantine/core";
 import { CHALLENGE_TYPES } from "@/classes/Challenge/ChallengeTypes";
 import { useEffect, useState } from "react";
 import ImageUpload from "@/components/inputs/ImageUpload/ImageUpload";
-import SubmitButton from "@/components/buttons/SubmitButton";
+import SubmitButton, { SubmitButtonSkeleton } from "@/components/buttons/SubmitButton";
 import { Challenge } from "@/classes/Challenge/Challenge";
 import useCreateOrEditChallengeForm from "@/hooks/CreateOrEditChallengeFormHook";
 import { useModal } from "@/components/modals/Modal";
@@ -91,6 +91,15 @@ export default function EditChallengeFormInner(props: Props) {
             )}
 
             <SubmitButton disabled={!form.isValid()} loading={loading} onClick={submitForm} />
+        </form>
+    );
+}
+
+export function EditChallengeFormInnerSkeleton() {
+    return (
+        <form className={`flex flex-col space-y-5`}>
+            <Skeleton w={"100%"} h={500} />
+            <SubmitButtonSkeleton />
         </form>
     );
 }

--- a/src/components/forms/edit-challenge/EditChallengeFormOuter.tsx
+++ b/src/components/forms/edit-challenge/EditChallengeFormOuter.tsx
@@ -1,7 +1,9 @@
-import TitleText from "@/components/text/TitleText";
+import TitleText, { TitleTextSkeleton } from "@/components/text/TitleText";
 import { Challenge } from "@/classes/Challenge/Challenge";
-import EditChallengeFormInner from "@/components/forms/edit-challenge/EditChallengeFormInner";
-import ChallengeStatusBadge from "@/components/badges/ChallengeStatusBadge";
+import EditChallengeFormInner, {
+    EditChallengeFormInnerSkeleton,
+} from "@/components/forms/edit-challenge/EditChallengeFormInner";
+import ChallengeStatusBadge, { ChallengeStatusBadgeSkeleton } from "@/components/badges/ChallengeStatusBadge";
 
 type Props = {
     challenge: Challenge;
@@ -15,6 +17,18 @@ export default function EditChallengeFormOuter(props: Props) {
                 <ChallengeStatusBadge challenge={props.challenge} />
             </div>
             <EditChallengeFormInner challenge={props.challenge} />
+        </div>
+    );
+}
+
+export function EditChallengeFormOuterSkeleton() {
+    return (
+        <div className={`flex flex-col space-y-5`}>
+            <div className="flex flex-row justify-between items-center">
+                <TitleTextSkeleton w={"50%"} />
+                <ChallengeStatusBadgeSkeleton />
+            </div>
+            <EditChallengeFormInnerSkeleton />
         </div>
     );
 }


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-frontend/issues/59

This pull request introduces skeleton components to improve the user experience by displaying loading states in the challenge editing interface. The most important changes include adding skeleton components for various parts of the form and updating the usage of these components in the relevant files.

Skeleton components addition:

* `src/app/admin/challenges/[id]/edit/page.tsx`: Imported `EditChallengeFormOuterSkeleton` and added a conditional rendering block to display it when the `loading` state is true. ([src/app/admin/challenges/[id]/edit/page.tsxL7-R15](diffhunk://#diff-33a60e79b571bcc29b1a32cc2825027af8462ce5a55a7dfac5e9f108daa4e934L7-R15), [src/app/admin/challenges/[id]/edit/page.tsxR26-R33](diffhunk://#diff-33a60e79b571bcc29b1a32cc2825027af8462ce5a55a7dfac5e9f108daa4e934R26-R33))
* [`src/components/forms/edit-challenge/EditChallengeFormInner.tsx`](diffhunk://#diff-6caa5937bedc2bd381f16b4ebe2e364b811c40bbdc668474e6ea807d5189ba14L3-R7): Added `Skeleton` and `SubmitButtonSkeleton` imports, and created the `EditChallengeFormInnerSkeleton` component to display a skeleton form. [[1]](diffhunk://#diff-6caa5937bedc2bd381f16b4ebe2e364b811c40bbdc668474e6ea807d5189ba14L3-R7) [[2]](diffhunk://#diff-6caa5937bedc2bd381f16b4ebe2e364b811c40bbdc668474e6ea807d5189ba14R97-R105)
* [`src/components/forms/edit-challenge/EditChallengeFormOuter.tsx`](diffhunk://#diff-d0b1b6df20cd4076c3a70ae59ef6d1439fee084e64fb27f49ab8d4b3b2b53a19L1-R6): Added `TitleTextSkeleton`, `EditChallengeFormInnerSkeleton`, and `ChallengeStatusBadgeSkeleton` imports, and created the `EditChallengeFormOuterSkeleton` component to display a skeleton outer form. [[1]](diffhunk://#diff-d0b1b6df20cd4076c3a70ae59ef6d1439fee084e64fb27f49ab8d4b3b2b53a19L1-R6) [[2]](diffhunk://#diff-d0b1b6df20cd4076c3a70ae59ef6d1439fee084e64fb27f49ab8d4b3b2b53a19R23-R34)