### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
 


### PR DESCRIPTION
Potential fix for [https://github.com/the-wedding-game/the-wedding-game-frontend/security/code-scanning/1](https://github.com/the-wedding-game/the-wedding-game-frontend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function. Based on the provided steps, the workflow primarily involves checking out code, setting up Node.js, installing dependencies, and building the project. These tasks only require `contents: read` permission. Therefore, we will set `permissions: contents: read` at the root level of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
